### PR TITLE
Remove unneeded var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
   tags = "${merge(var.common_tags,
-    map("Team Name", "${var.team_name}"),
     map("Team Contact", "#rpe")
     )}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,10 +34,6 @@ variable "jenkins_AAD_objectId" {
 
 variable "subscription" {}
 
-variable "team_name" {
-  default = "rpe"
-}
-
 variable "team_contact" {
   default = "#rpe"
 }


### PR DESCRIPTION
Jenkins library does team name automatically now
https://github.com/hmcts/cnp-jenkins-library/blob/master/src/uk/gov/hmcts/contino/TeamNames.groovy