### PR TITLE
Map PostgreSQL port to a non-default one

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,7 @@ services:
       mem_limit: 320m
       memswap_limit: 0
       ports:
-        - 5432:5432
+        - 5435:5432
 
     ccd-user-profile-api:
         image: hmcts/ccd-user-profile-api:latest


### PR DESCRIPTION
### Change description ###

Map PostgreSQL port to a non-default one so that people can still run PostgreSQL on their host machines.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
