### PR TITLE
Force terraform state change for the existing queue module

### DIFF
--- a/queue.tf
+++ b/queue.tf
@@ -7,7 +7,7 @@ module "queue-namespace" {
   common_tags         = "${var.common_tags}"
 }
 
-module "queue" {
+module "envelope-queue" {
   source              = "git@github.com:hmcts/terraform-module-servicebus-queue.git"
   name                = "envelopes"
   namespace_name      = "${module.queue-namespace.name}"
@@ -25,11 +25,11 @@ module "notification-queue" {
 }
 
 output "queue_primary_listen_connection_string" {
-  value = "${module.queue.primary_listen_connection_string}"
+  value = "${module.envelope-queue.primary_listen_connection_string}"
 }
 
 output "queue_primary_send_connection_string" {
-  value = "${module.queue.primary_send_connection_string}"
+  value = "${module.envelope-queue.primary_send_connection_string}"
 }
 
 output "notification_primary_listen_connection_string" {


### PR DESCRIPTION
### Change description ###

Since https://github.com/hmcts/terraform-module-servicebus-queue/pull/2 has been merged the existing state of the queue started to fail on new builds. Rename should force rebuild and hopefully solve the non-passing build which is happening since #49

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
