### PR TITLE
Force window to be within one hour starting from HH:00

### DIFF
--- a/no-envelopes-processed-alert.tf
+++ b/no-envelopes-processed-alert.tf
@@ -8,10 +8,11 @@ module "no-envelopes-processed-alert" {
   alert_desc = "Triggers when bulk scan processor did not process single envelope in last hour within SLA."
 
   app_insights_query = <<EOF
+let range_end = bin(now(), 1h);
 traces
-| where timestamp > ago(1h)
+| where timestamp > ago(2h)
 | where message startswith "Processing zip file"
-| make-series count(message) default=0 on timestamp in range(ago(1h), now(), 1m)
+| make-series count(message) default=0 on timestamp in range(range_end - 1h, range_end, 1m)
 | mvexpand count_message, timestamp
 | project files = toint(count_message), event_time = todatetime(timestamp)
 | summarize ["# files"] = sum(files), last_event = max(event_time)


### PR DESCRIPTION
### JIRA link (if applicable) ###

[No envelopes processed alert](https://tools.hmcts.net/jira/browse/BPS-541)

### Change description ###

Cause:

Whenever PR is merged and Jenkins build picks up the event upon completion alert is registered to kick off from `last updated + frequency`. Therefore alert can check window which is too early or too late. First option can cause the alert, second - will not. In both cases windows are not within SLA

Solution:

Strictly bound range to be exactly of module of an hour. This change assures window checks from 0900-1000 to 1600-1700

Summary:

After running the following:

```mql5
let range_end = bin(now(), 1h);
traces
| where timestamp > ago(2h)
| where message startswith "Processing zip file"
| make-series count(message) default=0 on timestamp in range(range_end - 1h, range_end, 1m)
| mvexpand count_message, timestamp
```

The result is as expected:

count_message | timestamp
--------------- | ----------
0 | 2019-03-12T13:00:00.0000000Z
8 | 2019-03-12T13:01:00.0000000Z
0 | 2019-03-12T13:02:00.0000000Z
8 | 2019-03-12T13:03:00.0000000Z
0 | 2019-03-12T13:04:00.0000000Z
... | ...
0 | 2019-03-12T13:45:00.0000000Z
0 | 2019-03-12T13:46:00.0000000Z
0 | 2019-03-12T13:47:00.0000000Z
0 | 2019-03-12T13:48:00.0000000Z
0 | 2019-03-12T13:49:00.0000000Z
... | ...
0 | 2019-03-12T14:00:00.0000000Z

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
