### PR TITLE
Bring configuration to the state before Key Vault module change

### DIFF
--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,5 +1,5 @@
 module "vault" {
-  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=REVERT-TO-COMMON-TAGS-COMMIT"
   name                    = "${var.product}-${var.env}"
   product                 = "${var.product}"
   env                     = "${var.env}"

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=1.22.1"
+  version = "=1.19.0"
 }
 
 locals {

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -1,7 +1,7 @@
 provider "azurerm" {
   alias           = "mgmt"
   subscription_id = "${var.mgmt_subscription_id}"
-  version         = "=1.22.1"
+  version         = "=1.19.0"
 }
 
 locals {


### PR DESCRIPTION
### Change description ###

Bring configuration to the state before Key Vault module change:
 * azurerm version 1.19.0
 * referencing the older version of cnp-module-key-vault module

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
