### PR TITLE
Store Service Bus connection strings and Storage Account secrets in Vault

### DIFF
--- a/alert_action_group.tf
+++ b/alert_action_group.tf
@@ -15,6 +15,12 @@ module "alert-action-group" {
   email_receiver_address = "${data.azurerm_key_vault_secret.source_bsp_email_secret.value}"
 }
 
+resource "azurerm_key_vault_secret" "alert_action_group_name" {
+  name = "alert-action-group-name"
+  value = "${module.alert-action-group.action_group_name}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
 output "action_group_name" {
   value = "${module.alert-action-group.action_group_name}"
 }

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -10,6 +10,11 @@ module "vault" {
   common_tags             = "${var.common_tags}"
 }
 
+data "azurerm_key_vault" "key_vault" {
+  name = "${module.vault.key_vault_name}"
+  resource_group_name = "${azurerm_resource_group.rg.name}"
+}
+
 output "vaultName" {
   value = "${module.vault.key_vault_name}"
 }

--- a/prod.tfvars
+++ b/prod.tfvars
@@ -2,5 +2,5 @@ external_hostname = "bulkscan.platform.hmcts.net"
 external_cert_name = "wildcard-platform-hmcts-net"
 external_cert_vault_uri = "https://infra-cert-prod.vault.azure.net/"
 
-envelope_queue_delivery_count = "300"
-notification_queue_delivery_count = "288" // To retry processing the message for 24hours
+envelope_queue_max_delivery_count = "300"
+notification_queue_max_delivery_count = "288" // To retry processing the message for 24hours

--- a/queue.tf
+++ b/queue.tf
@@ -36,7 +36,7 @@ module "processed-envelopes-queue" {
   lock_duration       = "PT5M"
 }
 
-# region connection strings as Key Vault secrets
+# region connection strings and other shared queue information as Key Vault secrets
 resource "azurerm_key_vault_secret" "envelopes_queue_send_conn_str" {
   name      = "envelopes-queue-send-connection-string"
   value     = "${module.envelopes-queue.primary_send_connection_string}"
@@ -46,6 +46,12 @@ resource "azurerm_key_vault_secret" "envelopes_queue_send_conn_str" {
 resource "azurerm_key_vault_secret" "envelopes_queue_listen_conn_str" {
   name      = "envelopes-queue-listen-connection-string"
   value     = "${module.envelopes-queue.primary_listen_connection_string}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "envelopes_queue_max_delivery_count" {
+  name      = "envelopes-queue-max-delivery-count"
+  value     = "${var.envelope_queue_delivery_count}"
   vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
 }
 

--- a/queue.tf
+++ b/queue.tf
@@ -36,6 +36,44 @@ module "processed-envelopes-queue" {
   lock_duration       = "PT5M"
 }
 
+# region connection strings as Key Vault secrets
+resource "azurerm_key_vault_secret" "envelopes_queue_send_conn_str" {
+  name      = "envelopes-queue-send-connection-string"
+  value     = "${module.envelopes-queue.primary_send_connection_string}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "envelopes_queue_listen_conn_str" {
+  name      = "envelopes-queue-listen-connection-string"
+  value     = "${module.envelopes-queue.primary_listen_connection_string}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "notifications_queue_send_conn_str" {
+  name      = "notifications-queue-send-connection-string"
+  value     = "${module.notifications-queue.primary_send_connection_string}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "notifications_queue_listen_conn_str" {
+  name      = "notifications-queue-listen-connection-string"
+  value     = "${module.notifications-queue.primary_listen_connection_string}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "processed_envelopes_queue_send_conn_str" {
+  name      = "processed-envelopes-queue-send-connection-string"
+  value     = "${module.processed-envelopes-queue.primary_send_connection_string}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "processed_envelopes_queue_listen_conn_str" {
+  name      = "processed-envelopes-queue-listen-connection-string"
+  value     = "${module.processed-envelopes-queue.primary_listen_connection_string}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+# endregion
+
 # deprecated, use `envelopes_queue_primary_listen_connection_string` instead
 output "queue_primary_listen_connection_string" {
   value = "${module.envelopes-queue.primary_listen_connection_string}"

--- a/queue.tf
+++ b/queue.tf
@@ -16,7 +16,7 @@ module "envelopes-queue" {
   requires_duplicate_detection            = "true"
   duplicate_detection_history_time_window = "PT1H"
   lock_duration                           = "PT5M"
-  max_delivery_count                      = "${var.envelope_queue_delivery_count}"
+  max_delivery_count                      = "${var.envelope_queue_max_delivery_count}"
 }
 
 module "notifications-queue" {
@@ -25,7 +25,7 @@ module "notifications-queue" {
   namespace_name      = "${module.queue-namespace.name}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   lock_duration       = "PT5M"
-  max_delivery_count  = "${var.notification_queue_delivery_count}"
+  max_delivery_count  = "${var.notification_queue_max_delivery_count}"
 }
 
 module "processed-envelopes-queue" {
@@ -51,7 +51,7 @@ resource "azurerm_key_vault_secret" "envelopes_queue_listen_conn_str" {
 
 resource "azurerm_key_vault_secret" "envelopes_queue_max_delivery_count" {
   name      = "envelopes-queue-max-delivery-count"
-  value     = "${var.envelope_queue_delivery_count}"
+  value     = "${var.envelope_queue_max_delivery_count}"
   vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
 }
 
@@ -115,5 +115,5 @@ output "processed_envelopes_queue_primary_send_connection_string" {
 }
 
 output "envelopes_queue_max_delivery_count" {
-  value = "${var.envelope_queue_delivery_count}"
+  value = "${var.envelope_queue_max_delivery_count}"
 }

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -62,6 +62,18 @@ resource "azurerm_storage_container" "service_rejected_containers" {
   count                = "${length(local.client_service_names)}"
 }
 
+resource "azurerm_key_vault_secret" "storage_account_name" {
+  name      = "storage-account-name"
+  value     = "${azurerm_storage_account.storage_account.name}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
+resource "azurerm_key_vault_secret" "storage_account_primary_key" {
+  name      = "storage-account-primary-key"
+  value     = "${azurerm_storage_account.storage_account.primary_access_key}"
+  vault_uri = "${data.azurerm_key_vault.key_vault.vault_uri}"
+}
+
 output "storage_account_name" {
   value = "${azurerm_storage_account.storage_account.name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,13 +39,13 @@ variable "common_tags" {
   type = "map"
 }
 
-variable "envelope_queue_delivery_count" {
+variable "envelope_queue_max_delivery_count" {
   type        = "string"
   default     = "10" // same as module's config
   description = "Envelope queue message max delivery counter. Extracted to variable so it can be assigned to application environment."
 }
 
-variable "notification_queue_delivery_count" {
+variable "notification_queue_max_delivery_count" {
   type        = "string"
   default     = "10" // same as module's config
   description = "Notification queue message max delivery counter. Extracted to variable so it can be overridden per environment."


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-599

### Change description ###

Store Service Bus connection strings and Storage Account secrets in Vault, so that the services' Terraform can access that information without having to rely on shared infrastructure's state file.

DO NOT MERGE - can only be merged after SIDAM go-live.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
