### PR TITLE
Fixed vault name based on subscription

### DIFF
--- a/app-gateway.tf
+++ b/app-gateway.tf
@@ -1,6 +1,6 @@
 data "azurerm_key_vault" "infra_vault" {
-  name = "${var.env == "prod" ? "infra-cert-${var.subscription}" : "infra-vault-${var.subscription}"}"
-  resource_group_name = "${var.env == "prod" ? "core-infra-prod" : "cnp-core-infra"}"
+  name = "${var.env == "prod" ? "infra-cert-prod" : "infra-vault-${var.subscription}"}"
+  resource_group_name = "${var.env == "prod" ? "infra-cert-prod" : "cnp-core-infra"}"
 }
 
 data "azurerm_key_vault_secret" "cert" {

--- a/app-gateway.tf
+++ b/app-gateway.tf
@@ -1,5 +1,5 @@
 data "azurerm_key_vault" "infra_vault" {
-  name = "infra-vault-${var.subscription}"
+  name = "${var.env == "prod" ? "infra-cert-${var.subscription}" : "infra-vault-${var.subscription}"}"
   resource_group_name = "${var.env == "prod" ? "core-infra-prod" : "cnp-core-infra"}"
 }
 


### PR DESCRIPTION

### Change description ###

- Working build on sandbox : https://sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_Platform/job/bulk-scan-shared-infrastructure/job/FIX-VAULT-NAME/

- Someone with prod access will need to check if the certs are available in resource group/vault name

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```