### PR TITLE
Update provider version as resource_group_name is removed waf module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "=1.22.1"
+  version = "=1.33.1"
 }
 
 locals {

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -43,6 +43,7 @@ resource "azurerm_storage_account" "storage_account" {
   network_rules {
     virtual_network_subnet_ids = ["${data.azurerm_subnet.trusted_subnet.id}", "${data.azurerm_subnet.jenkins_subnet.id}"]
     bypass                     = ["Logging", "Metrics", "AzureServices"]
+    default_action             = "Deny"
   }
 
   tags = "${local.tags}"

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -1,7 +1,7 @@
 provider "azurerm" {
   alias           = "mgmt"
   subscription_id = "${var.mgmt_subscription_id}"
-  version         = "=1.22.1"
+  version         = "=1.33.1"
 }
 
 locals {


### PR DESCRIPTION
# Change description ###

- `resource_group_name` was removed as part of https://github.com/hmcts/cnp-module-waf/pull/37

- `resource_group_name` is deprecated and hence the removal.

- pipeline currently fails with

```
Error: module.appGw.azurerm_storage_container.templates: "resource_group_name": required 
field is not set
```
as we use old version where it is mandatory


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
