### PR TITLE
Added managed identity obj id to access AAT vault

### DIFF
--- a/aat.tfvars
+++ b/aat.tfvars
@@ -1,2 +1,5 @@
 external_hostname = "bulkscan.aat.platform.hmcts.net"
+
 external_cert_name = "star-aat"
+
+managed_identity_object_id = "3fdc4187-bd0e-4180-aa7e-175f3f447aed"

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -8,10 +8,11 @@ module "vault" {
   resource_group_name     = "${azurerm_resource_group.rg.name}"
   product_group_object_id = "70de400b-4f47-4f25-a4f0-45e1ee4e4ae3"
   common_tags             = "${var.common_tags}"
+  managed_identity_object_id = "${var.managed_identity_object_id}"
 }
 
 data "azurerm_key_vault" "key_vault" {
-  name = "${module.vault.key_vault_name}"
+  name                = "${module.vault.key_vault_name}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -58,3 +58,7 @@ variable "payment_queue_max_delivery_count" {
 }
 variable "external_cert_name" {}
 variable "external_hostname" {}
+
+variable "managed_identity_object_id" {
+  default = ""
+}


### PR DESCRIPTION

### Change description ###

-  Currently `bulk-scan-payment-processor` master build is broken on AAT as the managed identity config for key vault is missing. This PR addresses that issue.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
