### PR TITLE
Added resource to set app insights instrumentation key to vault

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,5 +1,5 @@
 resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY" {
-  name         = "AppInsightsInstrumentationKey"
+  name         = "app-insights-instrumentation-key"
   value        = "${azurerm_application_insights.appinsights.instrumentation_key}"
   key_vault_id = "${module.vault.key_vault_id}"
 }

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,3 +1,9 @@
+resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY" {
+  name         = "AppInsightsInstrumentationKey"
+  value        = "${azurerm_application_insights.appinsights.instrumentation_key}"
+  key_vault_id = "${module.vault.key_vault_id}"
+}
+
 resource "azurerm_application_insights" "appinsights" {
   name                = "${var.product}-${var.env}"
   location            = "${var.appinsights_location}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/BPS-841

### Change description ###

- Added config to set app insights key into bulk scan vault.

- This will be later used in bulk scan processor chart which will is needed for the app. Other way is to do this was to configure in flux as an env var but that was not recommended approach.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
