### PR TITLE
Used pip upgrade branch to upgrade pip

### DIFF
--- a/palo-alto.tf
+++ b/palo-alto.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "palo_alto" {
-  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=master"
+  source       = "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"
   subscription = "${var.subscription}"
   env          = "${var.env}"
   product      = "${var.product}"


### PR DESCRIPTION

### Change description ###

- Currently build fails while activating the virtual environment with error 
```venv/bin/activate no such file or directory```.

- This is an attempt to see if that fixes the issue. Changes in Palo Alto repo are merged as it may impact other consumers of the module. Hence testing by referring to branch that contains upgrade changes.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
