### PR TITLE
Mark the build as successful after AAT deployment

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -8,4 +8,8 @@ withInfraPipeline(product) {
 
   enableSlackNotifications('#bsp-build-notices')
 
+  after('buildinfra:aat') {
+    currentBuild.result = 'SUCCESS'
+    currentBuild.description = "Stopping deployment to prod temporarily"
+  }
 }


### PR DESCRIPTION
### Change description ###

- Temporarily disable prod deployment as it causes a downtime to our supplier due to manual changes being applied to our infrastructure.

- This PR allows devs to merge to master which deploys infra changes to non prod environment thereby unblocking piling up of infra PR's.

- Also this way we can test our changes in non prod environment but also brings a bit risk that when we remove this lot of changes may be applied to prod infrastructure.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
