### PR TITLE
Halt before prod deployment

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -8,8 +8,7 @@ withInfraPipeline(product) {
 
   enableSlackNotifications('#bsp-build-notices')
 
-  after('buildinfra:aat') {
-    currentBuild.result = 'SUCCESS'
-    currentBuild.description = "Stopping deployment to prod temporarily"
+  before('buildinfra:prod') {
+    error('Halting pipeline before PROD.')
   }
 }


### PR DESCRIPTION

### Change description ###

Continuing from https://github.com/hmcts/bulk-scan-shared-infrastructure/pull/172 looks like we need to break the pipeline deliberately otherwise it just continues with prod deployment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
