### PR TITLE
Add team name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,13 @@ provider "azurerm" {
 }
 
 locals {
-  tags = "${merge(var.common_tags,
-    map("Team Contact", "#rpe")
+  tags = "${
+    merge(
+      var.common_tags,
+      map(
+        "Team Contact", "#rpe",
+        "Team Name", "Bulk Scan"
+      )
     )}"
 }
 

--- a/queue.tf
+++ b/queue.tf
@@ -4,7 +4,7 @@ module "queue-namespace" {
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   env                 = "${var.env}"
-  common_tags         = "${var.common_tags}"
+  common_tags         = "${local.tags}"
 }
 
 module "envelopes-queue" {


### PR DESCRIPTION
This seems to be mandatory now, PRs are failing with:
```
Error: module.queue-namespace.azurerm_template_deployment.namespace: 1 error(s) occurred:
* module.queue-namespace.azurerm_template_deployment.namespace: lookup: lookup failed to find 'Team Name' in:
${lookup(var.common_tags, "Team Name")}