### PR TITLE
DTSPO-5553 Switch to v2 storage

### DIFF
--- a/storage-account-staging.tf
+++ b/storage-account-staging.tf
@@ -19,7 +19,6 @@ resource "azurerm_storage_account" "storage_account_staging" {
   location                 = "${azurerm_resource_group.rg.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
-  account_kind             = "BlobStorage"
 
 #   custom_domain {
 #     name          = "${local.external_hostname_stg}"

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -35,7 +35,6 @@ resource "azurerm_storage_account" "storage_account" {
   location                 = "${azurerm_resource_group.rg.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
-  account_kind             = "BlobStorage"
 
 #   custom_domain {
 #     name          = "${var.external_hostname}"


### PR DESCRIPTION
Please see https://tools.hmcts.net/jira/browse/DTSPO-5553

This is step 1 of 2 in the Storage HA work in progress.
In order for Storage to use high availability we need to use a v2 account, currently this is using a v1 because of how it was setup.

This will be migrated in the background using an Azure migration process and then terraform ran afterwards to refresh the state