### PR TITLE
Update zoneRedundant variable to zone_redundant

### DIFF
--- a/queue-premium.tf
+++ b/queue-premium.tf
@@ -6,7 +6,7 @@ module "queue-namespace-premium" {
   env                 = var.env
   sku                 = "Premium"
   capacity            = 1
-  zoneRedundant      = true
+  zone_redundant      = true
   common_tags         = local.tags
 }
 

--- a/state.tf
+++ b/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=2.49.0"
+      version = "=2.99.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
### Change description ###
The `zoneRedundant` variable has been update to `zone_redundant` to follow the correct way to name variables in terraform 

https://www.terraform-best-practices.com/naming#general-conventions

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
