### PR TITLE
DTSPO-15909 - migrating app insights to workspace based.

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,27 +1,31 @@
 resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY" {
   name         = "app-insights-instrumentation-key"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "app_insights_connection_string" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.vault.key_vault_id
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.env}"
-  location            = var.appinsights_location
-  resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-  tags                = var.common_tags
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env      = var.env
+  product  = var.product
+  name     = "${var.product}"
+  location = var.appinsights_location
+
+  resource_group_name = azurerm_resource_group.rg.name
+
+  common_tags = var.common_tags
 }
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
+

--- a/dead-letter.tf
+++ b/dead-letter.tf
@@ -1,8 +1,8 @@
 // single alert to minify unnecessary cost because threshold used in here is minimal
 module "bulk-scan-dead-letter-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_Dead_Letter_-_BSP"

--- a/dlq-alert.tf
+++ b/dlq-alert.tf
@@ -1,8 +1,8 @@
 // single alert to minify unnecessary cost because threshold used in here is minimal
 module "bulk-scan-dlq-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module_application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_DLQ_-_BSP"

--- a/dlq-alert.tf
+++ b/dlq-alert.tf
@@ -2,7 +2,7 @@
 module "bulk-scan-dlq-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
   location          = var.appinsights_location
-  app_insights_name = module_application_insights.name
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_DLQ_-_BSP"

--- a/exception-alert.tf
+++ b/exception-alert.tf
@@ -1,8 +1,8 @@
 // single alert to minify unnecessary cost because threshold used in here is minimal
 module "bulk-scan-exception-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_exception_-_BSP"

--- a/heartbeat-alert.tf
+++ b/heartbeat-alert.tf
@@ -1,7 +1,7 @@
 module "envelopes-queue-heartbeat-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Envelope_Heartbeat_-_BSP"

--- a/incomplete-envelopes-alert.tf
+++ b/incomplete-envelopes-alert.tf
@@ -1,7 +1,7 @@
 module "bulk-scan-incomplete-envelopes-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_incomplete_envelopes_-_BSP"

--- a/liveness-alert.tf
+++ b/liveness-alert.tf
@@ -1,7 +1,7 @@
 module "bulk-scan-processor-liveness-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_Processor_liveness_-_BSP"
@@ -26,8 +26,8 @@ EOF
 
 module "bulk-scan-payment-processor-liveness-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_Payment_Processor_liveness_-_BSP"
@@ -52,8 +52,8 @@ EOF
 
 module "bulk-scan-orchestrator-liveness-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "Bulk_Scan_Orchestrator_liveness_-_BSP"

--- a/no-new-envelopes-alert.tf
+++ b/no-new-envelopes-alert.tf
@@ -1,7 +1,7 @@
 module "no-new-envelopes-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled     = var.env == "prod"
   alert_name  = "No_new_envelopes_-_Bulk_Scan_Processor"

--- a/orchestrator-scheduled-jobs-alerts.tf
+++ b/orchestrator-scheduled-jobs-alerts.tf
@@ -1,7 +1,7 @@
 module "consume-envelopes-queue-messages-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Consume_Envelopes_Queue_Messages_-_BSP"
@@ -22,8 +22,8 @@ module "consume-envelopes-queue-messages-alert" {
 
 module "delete-messages-from-envelopes-dlq-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Delete_Messages_From_Envelopes_Dlq_-_BSP"

--- a/payments-scheduled-jobs-alerts.tf
+++ b/payments-scheduled-jobs-alerts.tf
@@ -1,7 +1,7 @@
 module "consume-payments-queue-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Consume_Payments_Queue_Messages_-_BSP"

--- a/processor-scheduled-jobs-alerts.tf
+++ b/processor-scheduled-jobs-alerts.tf
@@ -1,7 +1,7 @@
 module "blob-processing-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Blob_Processing_-_BSP"
@@ -22,8 +22,8 @@ module "blob-processing-alert" {
 
 module "upload-documents-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Upload-Documents_-_BSP"
@@ -44,8 +44,8 @@ module "upload-documents-alert" {
 
 module "delete-rejected-files-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
   common_tags       = var.common_tags
 
   enabled    = var.env == "prod"
@@ -66,8 +66,8 @@ module "delete-rejected-files-alert" {
 
 module "delete-complete-files-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Delete_Completed_Files_-_BSP"
@@ -88,8 +88,8 @@ module "delete-complete-files-alert" {
 
 module "orchestrator-notifications-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Send_Orchestrator_Notification_-_BSP"
@@ -110,8 +110,8 @@ module "orchestrator-notifications-alert" {
 
 module "incomplete-envelopes-alert" {
   source            = "git@github.com:hmcts/cnp-module-metric-alert"
-  location          = azurerm_application_insights.appinsights.location
-  app_insights_name = azurerm_application_insights.appinsights.name
+  location          = var.appinsights_location
+  app_insights_name = module.application_insights.name
 
   enabled    = var.env == "prod"
   alert_name = "Bulk_Scan_Incomplete_Envelopes_Jobs_-_BSP"


### PR DESCRIPTION
Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

Change description
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.